### PR TITLE
added django-htmlmin to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ openpyxl==2.4.7
 numpy==1.12.1
 pylint==1.7.1
 pylint_django==0.7.2
+django-htmlmin==0.10.0


### PR DESCRIPTION
When I merged in I had to install this separately; it was not included among the packages that you install with `pip install -r requirements.txt`