### PR TITLE
Admin panel basic question statistics

### DIFF
--- a/malasakit-django/pcari/admin.py
+++ b/malasakit-django/pcari/admin.py
@@ -4,6 +4,7 @@ This module defines how Django should render the admin panel.
 
 from base64 import b64encode
 import json
+import math
 import os
 from urllib import urlencode
 
@@ -170,10 +171,22 @@ class CommentAdmin(ResponseAdmin):
     """
     Customizes admin change page functionality for `Comment`s.
     """
+    def display_mean_score(self, comment):
+        # pylint: disable=no-self-use
+        mean_score = comment.mean_score
+        return str(round(mean_score, 3)) if not math.isnan(mean_score) else '(No ratings)'
+    display_mean_score.short_description = 'Mean score'
+
+    def display_num_ratings(self, comment):
+        # pylint: disable=no-self-use
+        return comment.num_ratings
+    display_num_ratings.short_description = 'Number of ratings'
+
     # Columns to display in the Comment change list page, in order from left to
     # right
     list_display = ('respondent', 'message', 'timestamp', 'language',
-                    'flagged', 'tag', 'active')
+                    'flagged', 'tag', 'active', 'display_mean_score',
+                    'display_num_ratings')
 
     # By default first column listed in list_display is clickable; this makes
     # `message` column clickable

--- a/malasakit-django/pcari/admin.py
+++ b/malasakit-django/pcari/admin.py
@@ -86,6 +86,8 @@ class HistoryAdmin(admin.ModelAdmin):
     """
     save_as_continue = False
 
+    actions = ('mark_active', 'mark_inactive')
+
     def save_model(self, request, obj, form, change):
         if change and issubclass(obj.__class__, History):
             old_instance = obj.__class__.objects.get(id=obj.id)
@@ -103,6 +105,20 @@ class HistoryAdmin(admin.ModelAdmin):
             field_names.remove('active')
             return field_names
         return self.readonly_fields + ('predecessor', )
+
+    def mark_active(self, request, queryset):
+        """ Mark selected instances as active in bulk. """
+        num_marked = queryset.update(active=True)
+        message = '{0} row{1} successfully marked as active.'
+        message = message.format(num_marked, 's' if num_marked != 1 else '')
+        self.message_user(request, message)
+
+    def mark_inactive(self, request, queryset):
+        """ Mark selected instances as inactive in bulk. """
+        num_marked = queryset.update(active=False)
+        message = '{0} row{1} successfully marked as inactive.'
+        message = message.format(num_marked, 's' if num_marked != 1 else '')
+        self.message_user(request, message)
 
 
 class ResponseAdmin(HistoryAdmin):

--- a/malasakit-django/pcari/admin.py
+++ b/malasakit-django/pcari/admin.py
@@ -24,8 +24,8 @@ from .models import get_direct_fields
 
 class MalasakitAdminSite(admin.AdminSite):
     """
-    A custom admin site for Malasakit with augmented configuration and analytics
-    functionality.
+    A custom admin site for Malasakit with augmented configuration and
+    statistics functionality.
     """
     site_header = site_title = 'Malasakit'
 
@@ -34,8 +34,8 @@ class MalasakitAdminSite(admin.AdminSite):
         urls += [
             url(r'^configuration/$', self.admin_view(self.configuration),
                 name='configuration'),
-            url(r'^analytics/$', self.admin_view(self.analytics),
-                name='analytics'),
+            url(r'^statistics/$', self.admin_view(self.statistics),
+                name='statistics'),
             url(r'^change-bloom-icon/$', self.admin_view(require_POST(self.change_bloom_icon)),
                 name='change-bloom-icon'),
         ]
@@ -49,8 +49,8 @@ class MalasakitAdminSite(admin.AdminSite):
             del request.session['messages']
         return render(request, 'admin/configuration.html', context)
 
-    def analytics(self, request):
-        return render(request, 'admin/analytics.html', self.each_context(request))
+    def statistics(self, request):
+        return render(request, 'admin/statistics.html', self.each_context(request))
 
     def change_bloom_icon(self, request):
         """ Save an image file of a custom bloom icon. """

--- a/malasakit-django/pcari/static/js/client.js
+++ b/malasakit-django/pcari/static/js/client.js
@@ -171,9 +171,9 @@ class Resource {
 
 function initializeResources() {
     var comments = new Resource('comments', null, 12*60*60*1000,
-                                API_URL_ROOT + '/fetch-comments/');
+                                API_URL_ROOT + '/fetch/comments/');
     var qualitativeQuestions = new Resource('qualitative-questions', null, 0,
-                                            API_URL_ROOT + '/fetch-qualitative-questions/');
+                                            API_URL_ROOT + '/fetch/qualitative-questions/');
     var current = new Resource('current', null, 12*60*60*1000);
     var locationData = new Resource('location-data', null, 12*60*60*1000,
                                     STATIC_URL_ROOT + '/data/location-data.json');

--- a/malasakit-django/pcari/templates/admin/analytics.html
+++ b/malasakit-django/pcari/templates/admin/analytics.html
@@ -1,3 +1,0 @@
-{% extends 'admin/base_site.html' %}
-
-{% load i18n %}

--- a/malasakit-django/pcari/templates/admin/base.html
+++ b/malasakit-django/pcari/templates/admin/base.html
@@ -1,9 +1,11 @@
 {% extends 'admin/base.html' %}
 
+{% load i18n %}
+
 {% block userlinks %}
   {% if user.is_staff %}
-    <a href="{% url 'admin:configuration' %}">Configuration</a> /
+    <a href="{% url 'admin:configuration' %}">{% trans 'Configuration' %}</a> /
   {% endif %}
-  <a href="{% url 'admin:analytics' %}">Analytics</a> /
+  <a href="{% url 'admin:statistics' %}">{% trans 'Statistics' %}</a> /
   {{ block.super }}
 {% endblock %}

--- a/malasakit-django/pcari/templates/admin/configuration.html
+++ b/malasakit-django/pcari/templates/admin/configuration.html
@@ -2,6 +2,8 @@
 
 {% load i18n %}
 
+{% block title %}{% trans 'Site configuration' %}{% endblock %}
+
 {% block extrastyle %}
   {{ block.super }}
   <style>
@@ -33,14 +35,14 @@
 
 {% block content %}
   <div id="content-main">
-    <h1>Site configuration</h1>
+    <h1>{% trans 'Site configuration' %}</h1>
     <div class="module inline-group card-container">
-      <h2>Change bloom icon</h2>
+      <h2>{% trans 'Change bloom icon' %}</h2>
       <div class="card">
         <form action="{% url 'admin:change-bloom-icon' %}" method="POST" enctype="multipart/form-data">
           {% csrf_token %}
           <input id="bloom-icon" type="file" name="bloom-icon" accept="image/*">
-          <input type="submit">
+          <input type="submit" value="{% trans 'Submit' %}">
         </form>
       </div>
     </div>

--- a/malasakit-django/pcari/templates/admin/statistics.html
+++ b/malasakit-django/pcari/templates/admin/statistics.html
@@ -81,7 +81,17 @@
             position: 'bottom'
           },
           scales: {
+            xAxes: [{
+              scaleLabel: {
+                display: true,
+                labelString: 'Rating'
+              }
+            }],
             yAxes: [{
+              scaleLabel: {
+                display: true,
+                labelString: 'Number of respondents'
+              },
               ticks: {
                 beginAtZero:true
               }

--- a/malasakit-django/pcari/templates/admin/statistics.html
+++ b/malasakit-django/pcari/templates/admin/statistics.html
@@ -4,12 +4,155 @@
 
 {% block title %}{% trans 'Statistics' %}{% endblock %}
 
+{% block extrastyle %}
+  <style>
+    .card-container {
+      max-width: 1280px;
+    }
+
+    div.checkbox-container {
+      margin: 0.25rem 0;
+    }
+
+    input[type="checkbox"] {
+      margin: 0 0.5rem;
+    }
+  </style>
+{% endblock %}
+
 {% block extrahead %}
   <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.6.0/Chart.min.js"></script>
+  <script src="/static/js/jquery-3.2.1.min.js"></script>
+  <script>
+    var colorQueue = [
+        'rgba(17, 141, 255, 0.6)',  // blue
+        'rgba(47, 194, 70, 0.6)',  // green
+        'rgba(238, 65, 27, 0.6)',  // red
+        'rgba(119, 31, 218, 0.6)',  // purple
+        'rgba(218, 222, 50, 0.6)',  // yellow
+        'rgba(240, 158, 19, 0.6)',  // orange
+        'rgba(102, 201, 163, 0.6)',  // cyan
+        'rgba(184, 184, 184, 0.6)'  // silver
+    ];
+
+    function bindListener(checkbox, chart, ratingDistributions) {
+      checkbox.on('change', function() {
+        var questionID = $(this).attr('id');
+        if (questionID in ratingDistributions) {
+          if (checkbox.prop('checked')) {
+            var distribution = ratingDistributions[questionID];
+
+            var data = [distribution[-2] || 0, distribution[-1] || 0];
+            var choices = chart.data.labels.slice(2);
+            for (var index in choices) {
+              data.push(distribution[choices[index]]);
+            }
+
+            chart.data.datasets.push({
+              label: 'Question ' + questionID,
+              data: data,
+              backgroundColor: colorQueue.shift()
+            });
+          } else {
+            var datasets = chart.data.datasets;
+            for (var index in datasets) {
+              var dataset = datasets[index];
+              if (dataset.label === 'Question ' + questionID) {
+                colorQueue.push(dataset.backgroundColor);
+                datasets.splice(index, 1);
+                break;
+              }
+            }
+          }
+
+          chart.update();
+        }
+      });
+    }
+
+    $(document).ready(function() {
+      var canvas = $('#question-rating-distribution');
+      var language = $('html').attr('lang') || 'en';
+
+      var chart = new Chart(canvas, {
+        type: 'bar',
+        options: {
+          legend: {
+            position: 'bottom'
+          },
+          scales: {
+            yAxes: [{
+              ticks: {
+                beginAtZero:true
+              }
+            }]
+          }
+        }
+      });
+
+      var quantitativeQuestions, ratingDistributions = {};
+
+      $.getJSON('/api/fetch/quantitative-questions/', function(data) {
+        quantitativeQuestions = data;
+        for (var questionID in quantitativeQuestions) {
+          var translations = quantitativeQuestions[questionID];
+          if (language in translations) {
+            var prompt = translations[language];
+
+            var container = $('<div class="checkbox-container"></div>');
+            var checkbox = $('<input type="checkbox">')
+            var label = $('<label></label>')
+
+            checkbox.attr('id', questionID);
+            label.attr('for', questionID);
+            label.text('Question ' + questionID + ': "' + prompt + '"');
+            bindListener(checkbox, chart, ratingDistributions);
+
+            container.append(checkbox);
+            container.append(label);
+            $('#question-select').append(container);
+          }
+        }
+      });
+
+      $.getJSON('/api/fetch/question-ratings/', function(data) {
+        var max = -Infinity;
+        for (var ratingID in data) {
+          var rating = data[ratingID];
+          if (!(rating.qid in ratingDistributions)) {
+            ratingDistributions[rating.qid] = {};
+          }
+
+          var distribution = ratingDistributions[rating.qid];
+          if (!(rating.score in distribution)) {
+            distribution[rating.score] = 0
+          }
+          distribution[rating.score] += 1;
+
+          max = Math.max(max, rating.score);
+        }
+
+        var labels = ['(No answer)', '(Skipped)'];
+        for (var score = 0; score <= max; score++) {
+          labels.push(score.toString());
+        }
+        chart.data.labels = labels;
+        chart.update();
+      });
+    });
+  </script>
 {% endblock %}
 
 {% block content %}
   <div id="content-main">
     <h1>{% trans 'Statistics' %}</h1>
+    <div class="card-container">
+      <h2>{% trans 'Quantitative question rating distributions' %}</h2>
+      <canvas id="question-rating-distribution"></canvas>
+      <br>
+      <fieldset id="question-select">
+        <legend>Compare rating distributions</legend>
+      </fieldset>
+    </div>
   </div>
 {% endblock %}

--- a/malasakit-django/pcari/templates/admin/statistics.html
+++ b/malasakit-django/pcari/templates/admin/statistics.html
@@ -1,0 +1,15 @@
+{% extends 'admin/base_site.html' %}
+
+{% load i18n %}
+
+{% block title %}{% trans 'Statistics' %}{% endblock %}
+
+{% block extrahead %}
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.6.0/Chart.min.js"></script>
+{% endblock %}
+
+{% block content %}
+  <div id="content-main">
+    <h1>{% trans 'Statistics' %}</h1>
+  </div>
+{% endblock %}

--- a/malasakit-django/pcari/urls.py
+++ b/malasakit-django/pcari/urls.py
@@ -26,6 +26,8 @@ urlpatterns = [
 
 ajax_urlpatterns = [
     url(r'^fetch/comments/$', views.fetch_comments, name='fetch-comments'),
+    url(r'^fetch/quantitative-questions', views.fetch_quantitative_questions,
+        name='fetch_quantitative_questions'),
     url(r'^fetch/qualitative-questions/$', views.fetch_qualitative_questions,
         name='fetch-qualitative-questions'),
     url(r'^fetch/question-ratings/$', views.fetch_question_ratings,

--- a/malasakit-django/pcari/urls.py
+++ b/malasakit-django/pcari/urls.py
@@ -25,9 +25,11 @@ urlpatterns = [
 ]
 
 ajax_urlpatterns = [
-    url(r'^fetch-comments/$', views.fetch_comments, name='fetch-comments'),
-    url(r'^fetch-qualitative-questions/$', views.fetch_qualitative_questions,
+    url(r'^fetch/comments/$', views.fetch_comments, name='fetch-comments'),
+    url(r'^fetch/qualitative-questions/$', views.fetch_qualitative_questions,
         name='fetch-qualitative-questions'),
+    url(r'^fetch/question-ratings/$', views.fetch_question_ratings,
+        name='fetch-question-ratings'),
     url(r'^save-response/$', views.save_response, name='save-response'),
     url(r'^export-data/$', views.export_data, name='export-data'),
 ]

--- a/malasakit-django/pcari/views.py
+++ b/malasakit-django/pcari/views.py
@@ -235,6 +235,20 @@ def fetch_qualitative_questions(request):
 
 
 @profile
+@require_GET
+@staff_member_required
+def fetch_question_ratings(request):
+    ratings = QuantitativeQuestionRating.objects
+    ratings = ratings.filter(active=True).filter(question__active=True)
+    return JsonResponse({
+        str(rating.id): {
+            'qid': rating.question_id,
+            'score': rating.score,
+        } for rating in ratings
+    })
+
+
+@profile
 def make_question_ratings(respondent, responses):
     """ Generate new quantitative question model instances. """
     for question_id, scores in responses.get('question-ratings', {}).iteritems():


### PR DESCRIPTION
* Refactored API endpoints to include quantitative question and question rating data
* Added actions to support marking objects as active or inactive in bulk
* Added histograms for the admin panel (top right, "Statistics" link) using Chart.js
    * Can put multiple question distributions side-by-side
* Added mean score and number of ratings to the comment administration page