### PR TITLE
adjusted scale so mean responses divided into even bins

### DIFF
--- a/malasakit-django/pcari/templates/peer-responses.html
+++ b/malasakit-django/pcari/templates/peer-responses.html
@@ -57,9 +57,9 @@
             </blockquote>
             {% if num_ratings %}
               <div class="bubbled">
-                {% if question.mean_score <= 2 %}
+                {% if question.mean_score <= 2.667 %}
                   <img src="{% static 'img/red-emoticon.png' %}">
-                {% elif question.mean_score <= 4 %}
+                {% elif question.mean_score <= 4.333 %}
                   <img src="{% static 'img/yellow-emoticon.jpg' %}">
                 {% else %}
                   <img src="{% static 'img/green-emoticon.png' %}">


### PR DESCRIPTION
The mean responses were previously divided into red: 1-2, yellow: 2-4, green:4-6, which is uneven.
I am rebalancing the bins to be red: 1-2.667, yellow 2.667-4.333, green 4.333-6 so that each bin is the same size. 