### PR TITLE
make sure feature phone selected language is in settings.LANGUAGES

### DIFF
--- a/malasakit-django/feature_phone/views.py
+++ b/malasakit-django/feature_phone/views.py
@@ -192,7 +192,7 @@ class PromptLanguageView(PromptView):
 
 class SaveLanguageView(SaveView):
     """ Save listener language selections, and redirect them accordingly. """
-    next_view = 'feature-phone:prompt-irb-instructions'
+    next_view = 'feature-phone:prompt-irb-notice'
     key_to_language = {
         '1': 'en',
         '2': 'tl',

--- a/malasakit-django/feature_phone/views.py
+++ b/malasakit-django/feature_phone/views.py
@@ -184,7 +184,8 @@ class PromptLanguageView(PromptView):
         play_recording(action, Instructions.objects.get(key='language-selection', language='en'))
         for key in sorted(SaveLanguageView.key_to_language.keys()):
             language = SaveLanguageView.key_to_language[key]
-            if language != 'en':
+            language_codes_in_use = [code_and_name[0] for code_and_name in settings.LANGUAGES]
+            if language != 'en' and language in language_codes_in_use:
                 instruction = Instructions.objects.get(key='language-selection', language=language)
                 play_recording(action, instruction)
 

--- a/malasakit-django/feature_phone/views.py
+++ b/malasakit-django/feature_phone/views.py
@@ -203,6 +203,9 @@ class SaveLanguageView(SaveView):
     def save(self, request, voice_response):
         digit = request.POST.get('Digits')
         language = self.key_to_language.get(digit, settings.LANGUAGE_CODE)
+        language_codes_in_use = [code_and_name[0] for code_and_name in settings.LANGUAGES]
+        if language not in language_codes_in_use:
+            language = 'en'
 
         # pylint: disable=no-member
         related_object = web_models.Respondent.objects.create()


### PR DESCRIPTION
Summary:
Make the feature phone language prompt only ask for languages that are currently working. Previously, it prompted for all the languages including the ones that were not ready. It will now only prompt for languages in malasakit-django/cafe/settings.py under LANGUAGES, which can be accessed with settings.LANGUAGES (a list of tuple pairs where the first is a code such as 'en' and the second is 'English'

Testing:
made a trial twilio account and tested the difference in language prompt instructions between master and this branch. master askes for all 4 languages while this branch only asks for the 2 that are currently working